### PR TITLE
Fix bugs and cleanup mod

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,6 +1,6 @@
 name: luacheck
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,9 +3,6 @@ allow_defined_top = true
 
 globals = {
     "minetest",
-    "mesecons_stealthnode",
-    "mesecons_random",
-    "stealthnode"
 }
 
 read_globals = {
@@ -16,7 +13,7 @@ read_globals = {
     "vector", "ItemStack",
     "dump", "DIR_DELIM", "VoxelArea", "Settings",
 
-    -- MTG
+    -- Mod deps
     "default",
-    "mesecon"
+    "mesecon",
 }

--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,0 @@
-default
-mesecons_random

--- a/init.lua
+++ b/init.lua
@@ -1,115 +1,20 @@
 --[[
-    ********************************************
-    ***          Mesecons Stealthnodes        **
-    ********************************************
+	********************************************
+	***         Mesecons Stealthnodes        ***
+	********************************************
 
- A mod for Minetest to register various Ghoststones.
+	A mod for Minetest to register various Ghoststones.
 
 ]]--
 
 stealthnode = {}
 stealthnode.version = "1"
-stealthnode.revision = "3"
+stealthnode.revision = "5"
 
---[[
-    ********************************************
-    ***          Register Stealthnodes        **
-    ********************************************
+local modpath = minetest.get_modpath("mesecons_stealthnodes")
 
-    Registers a new Ghoststone with the tile of the given Node.
+dofile(modpath .. "/register.lua")
+dofile(modpath .. "/nodes.lua")
 
-    stealthnode.register_stealthnode(Name, Node)
-
-    Modname = String. Name of the Mod without ":", for example "default"
-    Node = String. Name of the registered Node
-
-]]--
-
-function stealthnode.register_stealthnode(modname, node)
-
-    local nodedef = minetest.registered_nodes[modname .. ":" .. node]
-    local tile
-
-    if nodedef == nil then
-        print("[MOD] " .. minetest.get_current_modname() .. ": "
-              .. modname .. ":" .. node .. " not found to register a stealthnode.")
-        minetest.log("warning", "[MOD] " .. minetest.get_current_modname() .. ": "
-                      .. modname .. ":" .. node .. " not found to register a stealthnode.")
-        return
-    else
-        tile = minetest.registered_nodes[modname .. ":" .. node].tiles
-
-    end
-
-    local newgroup = stealthnode.table_clone(nodedef.groups)
-
-    minetest.register_node(":mesecons_stealthnode:" .. modname .. "_" .. node, {
-        description="Stealthnode " .. nodedef.description,
-        tiles = tile,
-        drawtype = nodedef.drawtype,
-        sunlight_propagates = nodedef.sunlight_propagates,
-        paramtype = nodedef.paramtype,
-        is_ground_content = false,
-        inventory_image = tile,
-        groups = newgroup,
-        sounds = minetest.registered_nodes[modname .. ":" .. node].sounds,
-        mesecons = {conductor = {
-                    state = mesecon.state.off,
-                    rules = mesecon.rules.alldirs,
-                    onstate = "mesecons_stealthnode:" .. modname .. "_" .. node .. "_active"
-                    }},
-        on_blast = mesecon.on_blastnode,
-    })
-
-    minetest.register_node(":mesecons_stealthnode:" .. modname .. "_" .. node .. "_active", {
-        drawtype = "airlike",
-        pointable = false,
-        walkable = false,
-        diggable = false,
-        is_ground_content = false,
-        sunlight_propagates = true,
-        paramtype = "light",
-        drop = "mesecons_stealthnode:" .. modname .. "_" .. node,
-        mesecons = {conductor = {
-            state = mesecon.state.on,
-            rules = mesecon.rules.alldirs,
-            offstate = "mesecons_stealthnode:" .. modname .. "_" .. node
-        }},
-        on_construct = function(pos)
-            -- remove shadow
-            local shadowpos = vector.add(pos, vector.new(0, 1, 0))
-            if (minetest.get_node(shadowpos).name == "air") then
-                minetest.dig_node(shadowpos)
-            end
-        end,
-        on_blast = mesecon.on_blastnode,
-    })
-
-
-    minetest.register_craft({
-        output = 'mesecons_stealthnode:' .. modname .. "_" .. node .. ' 4',
-        recipe = {
-            {"default:tin_ingot", modname .. ":" .. node, "default:tin_ingot"},
-            {modname .. ":" .. node, "group:mesecon_conductor_craftable", modname .. ":" .. node},
-            {"default:tin_ingot", modname .. ":" .. node, "default:tin_ingot"},
-        }
-    })
-
-end -- function stealthnode.register_stealth_node(
-
-
-function stealthnode.table_clone(c_table)
-  local t2 = {}
-  for k,v in pairs(c_table) do
-    t2[k] = v
-
-  end
-
-  return t2
-
-end -- function cucina_vegana.table_clone
-
-dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/register.lua")
-
-print("[MOD] " .. minetest.get_current_modname() .. " loaded.")
-minetest.log("info", "[MOD] " .. minetest.get_current_modname() .. " loaded.")
+print("[MOD] Mesecons Stealthnodes loaded.")
+minetest.log("info", "[MOD] Mesecons Stealthnodes loaded.")

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = mesecons_stealthnodes
 description = A mod to register Ghoststones.
-depends = default,  mesecons_random
+depends = default, mesecons_random
 optional_depends = moreores

--- a/nodes.lua
+++ b/nodes.lua
@@ -1,0 +1,79 @@
+--[[
+	********************************************
+	***              Stealthnodes            ***
+	********************************************
+
+	Adds various Stealthnodes for nodes from "default" and "moreores".
+
+]]--
+
+local nodes = {
+
+	{"default", "dirt"},
+	{"default", "dry_dirt"},
+	{"default", "permafrost"},
+	{"default", "gravel"},
+	{"default", "clay"},
+	{"default", "snowblock"},
+	{"default", "ice"},
+	{"default", "coral_skeleton"},
+
+	{"default", "sand"},
+	{"default", "silver_sand"},
+	{"default", "desert_sand"},
+
+	{"default", "cobble"},
+	{"default", "mossycobble"},
+	{"default", "desert_cobble"},
+
+	{"default", "stone"},
+	{"default", "stonebrick"},
+	{"default", "stone_block"},
+
+	{"default", "glass"},
+	{"default", "obsidian_glass"},
+
+	{"default", "desert_stone"},
+	{"default", "desert_stonebrick"},
+	{"default", "desert_stone_block"},
+
+	{"default", "sandstone"},
+	{"default", "sandstonebrick"},
+	{"default", "sandstone_block"},
+
+	{"default", "desert_sandstone"},
+	{"default", "desert_sandstone_brick"},
+	{"default", "desert_sandstone_block"},
+
+	{"default", "silver_sandstone"},
+	{"default", "silver_sandstone_brick"},
+	{"default", "silver_sandstone_block"},
+
+	{"default", "obsidian"},
+	{"default", "obsidianbrick"},
+	{"default", "obsidian_block"},
+
+	{"default", "wood"},
+	{"default", "tree"},
+
+	{"default", "junglewood"},
+	{"default", "jungletree"},
+
+	{"default", "aspen_wood"},
+	{"default", "aspen_tree"},
+
+	{"default", "pine_wood"},
+	{"default", "pine_tree"},
+
+	{"default", "acacia_wood"},
+	{"default", "acacia_tree"},
+
+	{"moreores", "mithril_block"},
+	{"moreores", "silver_block"},
+}
+
+for _,value in pairs(nodes) do
+	if minetest.get_modpath(value[1]) then
+		stealthnode.register_stealthnode(value[1], value[2])
+	end
+end

--- a/register.lua
+++ b/register.lua
@@ -1,88 +1,105 @@
+
 --[[
-       ********************************************
-       **                                        **
-       **           Stealthnode-Register         **
-       **                                        **
-       **        Helpmod for Stealthnode to      **
-       **      easy Register new Stealthnodes    **
-       **                                        **
-       ********************************************
+    ********************************************
+    ***         Register Stealthnodes        ***
+    ********************************************
+
+    Registers a new Stealthnode with the tile of the given node.
+
+    stealthnode.register_stealthnode(modname, node)
+
+    modname = String. Name of the mod without ":", for example "default".
+    node = String. Name of the registered node, for example "sandstone".
+
 ]]--
 
-local snodes = {
+local function copy_table(t)
+	if type(t) ~= "table" then return end
+	local t2 = {}
+	for k,v in pairs(t) do
+		t2[k] = v
+	end
+	return t2
+end
 
-		{"default", "dirt"},
-		{"default", "dry_dirt"},
-		{"default", "permafrost"},
-		
-		{"default", "sand"},
-		{"default", "silver_sand"},
-		{"default", "desert_sand"},
-		
-		{"default", "gravel"},
-		{"default", "clay"},
-		{"default", "snowblock"},
-		
-		{"default", "ice"},
-		{"default", "cave_ice"},
-		
-                {"default", "cobble"},
-                {"default", "stone"},
-                {"default", "stonebrick"},
-                {"default", "stone_block"},
-		{"default", "mossycobble"},
-		
-                --{"default", "glass"},
-                --{"default", "obsidian_glass"},
+function stealthnode.register_stealthnode(modname, node)
 
-                {"default", "desert_cobble"},
-                {"default", "desert_stone"},
-                {"default", "desert_stonebrick"},
-                {"default", "desert_stone_block"},
+	local node_name = modname .. ":" .. node
 
-                {"default", "sandstone"},
-                {"default", "sandstonebrick"},
-                {"default", "sandstone_block"},
+	local nodedef = minetest.registered_nodes[node_name]
 
-                {"default", "desert_sandstone"},
-                {"default", "desert_sandstone_brick"},
-                {"default", "desert_sandstone_block"},
+	if not nodedef then
+		local message = "[MOD] " .. minetest.get_current_modname() .. ": "
+			.. node_name .. " not found to register a stealthnode."
+		print(message)
+		minetest.log("warning", message)
+		return
+	end
 
-                {"default", "silver_sandstone"},
-                {"default", "silver_sandstone_brick"},
-                {"default", "silver_sandstone_block"},
+	local stealthnode_name = "mesecons_stealthnode:" .. modname .. "_" .. node
 
-                {"default", "obsidian"},
-                {"default", "obsidianbrick"},
-                {"default", "obsidian_block"},
-		
-		{"default", "coral_skeleton"},
-		
-                {"default", "wood"},
-                --{"default", "tree"},
+	local node_groups = copy_table(nodedef.groups) or {}
+	node_groups.mesecons_stealthnode = 1
 
-                {"default", "junglewood"},
-                --{"default", "jungletree"},
+	minetest.register_node(":" .. stealthnode_name, {
+		description = "Stealthnode " .. nodedef.description,
+		drawtype = nodedef.drawtype,
+		tiles = nodedef.tiles,
+		use_texture_alpha = nodedef.use_texture_alpha,
+		paramtype = nodedef.paramtype,
+		paramtype2 = nodedef.paramtype2,
+		is_ground_content = false,
+		sunlight_propagates = nodedef.sunlight_propagates,
+		node_box = nodedef.node_box,
+		mesh = nodedef.mesh,
+		selection_box = nodedef.selection_box,
+		collision_box = nodedef.collision_box,
+		sounds = nodedef.sounds,
+		groups = node_groups,
+		inventory_image = nodedef.inventory_image,
+		mesecons = {
+			conductor = {
+				state = mesecon.state.off,
+				rules = mesecon.rules.alldirs,
+				onstate = stealthnode_name .. "_active",
+			}
+		},
+		on_blast = mesecon.on_blastnode,
+	})
 
-                {"default", "aspen_wood"},
-                --{"default", "aspen_tree"},
+	minetest.register_node(":" .. stealthnode_name .. "_active", {
+		drawtype = "airlike",
+		paramtype = "light",
+		is_ground_content = false,
+		sunlight_propagates = true,
+		pointable = false,
+		walkable = false,
+		diggable = false,
+		drop = stealthnode_name,
+		groups = {mesecons_stealthnode_active = 1, not_in_creative_inventory = 1},
+		mesecons = {
+			conductor = {
+				state = mesecon.state.on,
+				rules = mesecon.rules.alldirs,
+				offstate = stealthnode_name,
+			}
+		},
+		on_construct = function(pos)
+			-- remove shadow
+			local shadowpos = vector.add(pos, vector.new(0, 1, 0))
+			if minetest.get_node(shadowpos).name == "air" then
+				minetest.dig_node(shadowpos)
+			end
+		end,
+		on_blast = mesecon.on_blastnode,
+	})
 
-                {"default", "pine_wood"},
-                --{"default", "pine_tree"},
-
-                {"default", "acacia_wood"},
-                --{"default", "acacia_tree"},
-
-                {"moreores", "mithril_block"},
-
-            }
-
-local register = stealthnode.register_stealthnode
-for i,value in pairs(snodes) do
-    if(minetest.registered_nodes[value[1]..":"..value[2]]) then
-	register(value[1], value[2])
-    else
-        minetest.log("info","[MOD]stealthnode:Node ".. value[1]..":"..value[2].." not found to register a Stealthnode.")
-    end -- if(mintest.registered_nodes
-
-end -- for i,value
+	minetest.register_craft({
+		output = stealthnode_name .. " 4",
+		recipe = {
+			{"default:tin_ingot", node_name, "default:tin_ingot"},
+			{node_name, "group:mesecon_conductor_craftable", node_name},
+			{"default:tin_ingot", node_name, "default:tin_ingot"},
+		}
+	})
+end


### PR DESCRIPTION
Fixes multiple bugs including #2, and cleans up various things.

- Fix inventory image bug (#2) by using inventory image from source node
- Fix active stealthnodes appearing in inventory by adding `not_in_creative_inventory` group.
- Improve stealthnodes by copying more from source node (such as `paramtype2`, which allows rotation for logs and bricks).
- Add `mesecons_stealthnode` group to stealthnodes , and `mesecons_stealthnode_active` group to active stealthnodes.
- Restore stealthnodes removed in 886a58a.
- Remove unnecessary `modpack.txt` and `depends.txt` files. 
- Remove some unnecessary stuff from luacheck.